### PR TITLE
Correct documentation of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Many thanks to and inspiration from: https://github.com/arankwende/meshtastic-mq
 
 Requires packages: Meshtastic, Paho-MQTT v2, Tkinter, cryptography which might be installed with:
 
-`pip3 install meshtastic paho-mqtt tk cryptography`
+`pip3 install meshtastic paho-mqtt tkinter cryptography`
 
 *** Mac OS Sonoma (and maybe others) ***
 There is an upstream bug in Tkinter where mouse clicks in the UI are not registered, unless the mouse is in motion.


### PR DESCRIPTION
Hi, I just noticed this mistake in the list of Python packages.

Also in case you’re interested, I’ve drafted [a Nix package](https://codeberg.org/AndrewKvalheim/configuration/src/branch/main/packages/mqtt-connect.nix) (this is just how I install things) with a couple of edits that you’re welcome to borrow from if you’d like.